### PR TITLE
feat: Dodaj 3-way odabir GPS agregata za mesečni izveštaj

### DIFF
--- a/apps/admin-portal/src/services/driving-behavior.service.ts
+++ b/apps/admin-portal/src/services/driving-behavior.service.ts
@@ -79,13 +79,17 @@ class DrivingBehaviorService {
 
   /**
    * OPTIMIZED: Get statistics for multiple vehicles in a single request
-   * DUAL MODE: Supports both VIEW aggregates (fast) and direct calculation (reliable)
+   * TRIPLE MODE: Supports 3 calculation methods:
+   *   1. NO-PostGIS VIEW aggregates (fastest, default)
+   *   2. PostGIS VIEW aggregates (backup)
+   *   3. Direct from gps_data (slowest, emergency)
    */
   async getBatchStatistics(
     vehicleIds: number[],
     startDate: string,
     endDate: string,
-    useDirectCalculation?: boolean
+    useDirectCalculation?: boolean,
+    aggregateType?: 'no_postgis' | 'postgis'
   ): Promise<VehicleStatistics[]> {
     try {
       const response = await axios.post(
@@ -94,7 +98,8 @@ class DrivingBehaviorService {
           vehicleIds,
           startDate,
           endDate,
-          useDirectCalculation: useDirectCalculation ?? false
+          useDirectCalculation: useDirectCalculation ?? false,
+          aggregateType: aggregateType ?? 'no_postgis'
         },
         {
           headers: this.getAuthHeaders(),

--- a/apps/backend/src/driving-behavior/driving-behavior.controller.ts
+++ b/apps/backend/src/driving-behavior/driving-behavior.controller.ts
@@ -156,14 +156,17 @@ export class DrivingBehaviorController {
 
   /**
    * OPTIMIZED: Get statistics for multiple vehicles at once
-   * DUAL MODE: Supports both VIEW aggregates (fast) and direct calculation (reliable)
+   * TRIPLE MODE: Supports 3 calculation methods
    */
   @Post('batch-statistics')
   @ApiOperation({
     summary: 'Get statistics for multiple vehicles (BATCH)',
     description:
       'Returns aggregated statistics for multiple vehicles in a single request - optimized for monthly reports. ' +
-      'Supports dual mode: VIEW aggregates (fast, default) or direct calculation from gps_data (slower but reliable).',
+      'Supports 3 modes: ' +
+      '1. NO-PostGIS VIEW aggregates (fastest, default, Haversine formula), ' +
+      '2. PostGIS VIEW aggregates (backup, ST_Distance), ' +
+      '3. Direct from gps_data (slowest, emergency, ST_Distance).',
   })
   @ApiResponse({
     status: 200,
@@ -178,6 +181,7 @@ export class DrivingBehaviorController {
       dto.startDate,
       dto.endDate,
       dto.useDirectCalculation ?? false,
+      dto.aggregateType,
     );
   }
 

--- a/apps/backend/src/driving-behavior/dto/driving-events.dto.ts
+++ b/apps/backend/src/driving-behavior/dto/driving-events.dto.ts
@@ -21,6 +21,11 @@ export enum SeverityLevel {
   SEVERE = 'severe',
 }
 
+export enum AggregateType {
+  NO_POSTGIS = 'no_postgis', // Novi agregat БEZ PostGIS (brži, default)
+  POSTGIS = 'postgis', // Stari agregat SA PostGIS (backup)
+}
+
 export class DrivingEventDto {
   @ApiProperty({ description: 'Event ID' })
   id: number;
@@ -227,8 +232,19 @@ export class BatchStatisticsDto {
   endDate: string;
 
   @ApiProperty({
+    enum: AggregateType,
     description:
-      'Use direct calculation from gps_data (slower but reliable) instead of VIEW aggregates',
+      'Aggregate type: no_postgis (БEZ PostGIS, brži, default) ili postgis (SA PostGIS, backup)',
+    required: false,
+    default: AggregateType.NO_POSTGIS,
+  })
+  @IsOptional()
+  @IsEnum(AggregateType)
+  aggregateType?: AggregateType;
+
+  @ApiProperty({
+    description:
+      'Zaobiđi aggregate-e i računaj direktno iz gps_data tabele (najsporije, emergency)',
     required: false,
     default: false,
   })


### PR DESCRIPTION
Implementirana mogućnost odabira između 3 metode računanja kilometraže:
1. NO-PostGIS VIEW agregati (najbrži, default, Haversine formula)
2. PostGIS VIEW agregati (backup, ST_Distance)
3. Direktno iz gps_data (najsporije, emergency, ST_Distance)

Backend izmene:
- Dodao enum AggregateType (no_postgis, postgis)
- Modifikovao BatchStatisticsDto sa aggregateType parametrom
- Kreirao getDistanceStatsFromNoPostGISViews() funkciju
- Refaktorisao getBatchMonthlyStatistics() sa 3-way logikom
- Ažurirao Controller i API dokumentaciju

Frontend izmene:
- Dodao aggregateType state u MonthlyReport komponentu
- Implementirao UI sa Switch (VIEW/Direct) + Radio buttons (PostGIS/No-PostGIS)
- Ažurirao drivingBehaviorService sa novim parametrom
- Dinamički opis odabrane metode

Default: NO-PostGIS VIEW agregati (najbrži)

🤖 Generated with [Claude Code](https://claude.com/claude-code)